### PR TITLE
Get fav error from errors array

### DIFF
--- a/autoload/twitvim.vim
+++ b/autoload/twitvim.vim
@@ -2477,7 +2477,7 @@ function! s:fave_tweet(unfave)
     let [error, output] = s:run_curl_oauth_post(url, { 'id' : id })
     let result = s:parse_json(output)
     if error != ''
-        let errormsg = get(result, 'error', '')
+        let errormsg = join(map(get(result, 'errors', []), 'get(v:val, "message", "")'), ",")
         call s:errormsg("Error ".(a:unfave ? 'unfavoriting' : 'favoriting')." the tweet: ".(errormsg != '' ? errormsg : error))
         return
     endif


### PR DESCRIPTION
This fixes a missed error where if you tried to fav a tweet you had
already fav'd, it would just say you got a 403 forbidden response. With
this change you now get: "Error favoriting the tweet: You have already
favorited this status."
