### PR TITLE
Allow posting newlines in tweets

### DIFF
--- a/autoload/twitvim.vim
+++ b/autoload/twitvim.vim
@@ -171,6 +171,12 @@ function! s:get_net_timeout()
     return get(g:, 'twitvim_net_timeout', 10)
 endfunction
 
+" Don't strip newlines from tweets being posted
+" Default is 0 so newlines will get replaced by single spaces
+function! s:get_allow_multiline()
+    return get(g:, 'twitvim_allow_multiline', 0)
+endfunction
+
 " If user install vimproc, prefer to use vimproc.
 try
   call vimproc#version()
@@ -2127,8 +2133,10 @@ function! s:post_twitter(mesg, inreplyto)
     " line. Don't let it count towards the tweet length.
     let mesg = substitute(mesg, '\n$', '', "")
 
-    " Convert internal newlines to spaces.
-    let mesg = substitute(mesg, '\n', ' ', "g")
+    if !s:get_allow_multiline()
+      " Convert internal newlines to spaces.
+      let mesg = substitute(mesg, '\n', ' ', "g")
+    endif
 
     let mesglen = s:mbstrlen(mesg)
     " Check for zero-length tweets or user cancel at prompt.

--- a/doc/twitvim.txt
+++ b/doc/twitvim.txt
@@ -166,6 +166,7 @@ License: The Vim License applies to twitvim.vim and twitvim.txt (see
 	6.1. Timeline Hotkeys.....................: |TwitVim-hotkeys|
 	6.2. Line length in status line...........: |TwitVim-line-length|
 	6.3. Network timeout......................: |TwitVim-network-timeout|
+	6.4. Post Tweets including newlines.......: |TwitVim-allow-multiline|
 	7. History................................: |TwitVim-history|
 	8. Credits................................: |TwitVim-credits|
 
@@ -1660,6 +1661,20 @@ License: The Vim License applies to twitvim.vim and twitvim.txt (see
 	Note: This option does not seem to work correctly if you are using
 	|twitvim_enable_perl|. It may take longer than that number of seconds
 	to time out.
+
+
+------------------------------------------------------------------------------
+6.4. Post Tweets including newlines		*TwitVim-allow-multiline*
+
+	By default TwitVim will strip newlines from tweets. This is apparent
+	when posting from a buffer.
+
+						*twitvim_allow_multiline*
+	You can set twitvim_allow_multiline to allow posting multiline
+	messages. Just add the following to your vimrc:
+>
+		let twitvim_allow_multiline = 1
+<
 
 
 ==============================================================================

--- a/plugin/twitvim.vim
+++ b/plugin/twitvim.vim
@@ -95,7 +95,7 @@ nnoremenu Plugin.TwitVim.Post\ current\ line :call twitvim#post_twitter(getline(
 
 " Post entire buffer to Twitter.
 if !exists(":BPosttoTwitter")
-    command BPosttoTwitter :call twitvim#post_twitter(join(getline(1, "$")), 0)
+    command BPosttoTwitter :call twitvim#post_twitter(join(getline(1, "$"), "\n"), 0)
 endif
 
 " Post visual selection to Twitter.


### PR DESCRIPTION
Previously if used `:BPostToTwitter` all the lines would be joined with
spaces. Now they are joined with newlines so that the tweet will be
posted exactly how it was written by the user.
