### PR TITLE
Fix shell's redirection operator

### DIFF
--- a/autoload/twitvim.vim
+++ b/autoload/twitvim.vim
@@ -2562,9 +2562,9 @@ function! s:launch_browser(url)
     " Discard unnecessary output from UNIX browsers. So far, this is known to
     " happen only in the Linux version of Google Chrome when it opens a tab in
     " an existing browser window.
-    " Firefox appears to output to stderr as well, so the '2&>1' redirect is
+    " Firefox appears to output to stderr as well, so the '2>&1' redirect is
     " needed.
-    let endcmd = has('unix') ? '> /dev/null 2&>1 &' : ''
+    let endcmd = has('unix') ? '> /dev/null 2>&1 &' : ''
 
     " Escape characters that have special meaning in the :! command.
     let url = substitute(a:url, '!\|#\|%', '\\&', 'g')


### PR DESCRIPTION
when stderr is redirected to stdout, '&' should be placed after '>', not before in this format.
'2&>1' causes an error in fish shell.
```fish
fish> open https://twitter.com > /dev/null 2&>1
Expected a command, but instead found a redirection
fish: open https://twitter.com > /dev/null 2&>1
                                             ^
```