### PR TITLE
fix "Not an editor command" errors

### DIFF
--- a/autoload/twitvim.vim
+++ b/autoload/twitvim.vim
@@ -3656,7 +3656,7 @@ function! s:pick_woeid_town(country)
         elseif select == 'previous page'
             let indx -= pagelen
             if indx < 0
-                indx = 0
+                let indx = 0
             endif
         else
             let g:twitvim_woeid = s:get_woeid(a:country, select)
@@ -3699,7 +3699,7 @@ function! twitvim#pick_woeid()
         elseif select == 'previous page'
             let indx -= pagelen
             if indx < 0
-                indx = 0
+                let indx = 0
             endif
         else
             if s:woeid_list[select]['towns'] == {}


### PR DESCRIPTION
I've interpreted that these statements were trying to assign to variables: `indx`s, so I added `let`.